### PR TITLE
Fix local invalid token error

### DIFF
--- a/Backend/check-env.js
+++ b/Backend/check-env.js
@@ -2,7 +2,8 @@
  * Script de diagnóstico para verificar variables de entorno
  */
 
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 
 console.log('🔍 Verificando archivo .env...\n');
 
@@ -17,7 +18,7 @@ console.log('PORT:', process.env.PORT || '❌ NO ENCONTRADA');
 console.log('JWT_SECRET:', process.env.JWT_SECRET ? '✅ ENCONTRADA' : '❌ NO ENCONTRADA');
 
 console.log('\n📁 Ruta del archivo .env esperada:');
-console.log(require('path').join(__dirname, '.env'));
+console.log(path.join(__dirname, '.env'));
 
 console.log('\n💡 Si las variables de Cloudinary no aparecen:');
 console.log('1. Asegúrate de que el archivo Backend/.env existe');

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
-require('dotenv').config();
+// Cargar variables de entorno desde Backend/.env sin depender del CWD
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 
 // Importar la configuración de la base de datos
 const { testConnection } = require('./db');


### PR DESCRIPTION
Explicitly load backend environment variables from `Backend/.env` to fix "token inválido" errors locally.

The backend was not consistently loading environment variables from `Backend/.env` when run locally, leading to `JWT_SECRET` being undefined and causing "token inválido" errors. This change ensures the `.env` file is always loaded correctly, regardless of the current working directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-508c6f4b-3871-4cfc-bc5e-8e0ac0cf827d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-508c6f4b-3871-4cfc-bc5e-8e0ac0cf827d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

